### PR TITLE
Fix string inline error

### DIFF
--- a/masm_shc/main.cpp
+++ b/masm_shc/main.cpp
@@ -196,8 +196,12 @@ bool process_file(t_params &params)
             ofile << consts_lines[curr_const] << "\n";
             ofile << label_after << ":\n";
             if (tokens.size() > 2 && (tokens[0] == "lea" || tokens[0] == "mov")) {
-                std::string reg = tokens[1];
-                ofile << "\tPOP  " << reg << "\n";
+                auto offset_index = find(tokens.begin() + 1, tokens.end(), "OFFSET");
+                std::string instructions = tokens[1];
+                if(std::distance(tokens.begin(), offset_index) == 4) {
+                    instructions = tokens[1] + " " + tokens[2]+ " " + tokens[3];
+                }
+                ofile << "\tPOP  " << instructions << "\n";
             }
             ofile << "\n";
             ofile << "; " << line << "\n"; //copy commented out line


### PR DESCRIPTION
#  masm_shc string inline error

## reproduce

source file `test.cpp`:

```c
#include <stdio.h>
void main() {
    char* temp[] = {"123", "xxx", "bbb"};
    return;
}

```

use `test.bat` to build:

```bat
cl /c /FA /GS- test.cpp
masm_shc.exe test.asm test_a.asm
ml test_a.asm /link /entry:main
```

`cl.exe` output `test.asm`:

```asm

; Line 7
	mov	DWORD PTR _temp$[ebp], OFFSET $SG5652
	mov	DWORD PTR _temp$[ebp+4], OFFSET $SG5653
	mov	DWORD PTR _temp$[ebp+8], OFFSET $SG5654
; Line 8

```

`masm_shc.exe` output `test_a.asm`:

```asm
; Line 7
	CALL after_$SG5652
$SG5652	DB	'123', 00H
after_$SG5652:
	POP  DWORD

; 	mov	DWORD PTR _temp$[ebp], OFFSET $SG5652
	CALL after_$SG5653
$SG5653	DB	'xxx', 00H
after_$SG5653:
	POP  DWORD
```

expect:

```
POP DWORD PTR _temp$[ebp]
```

actual:
```
POP DWORD
```

